### PR TITLE
Bug 40: Uploaded Consent Form Displays for All Treatments

### DIFF
--- a/src/app/components/patients-section/treatment-plans/consent-form/consent-form.component.html
+++ b/src/app/components/patients-section/treatment-plans/consent-form/consent-form.component.html
@@ -16,6 +16,39 @@
         Upload Form
       </button>
     </div>
+    <!-- Uploaded Files List -->
+      <div class="uploaded-files" *ngIf="uploadedForms.length > 0 && !shouldShowNoConsentMessage()">
+        <h4 *ngIf="!viewOnly">Consent Forms:</h4>
+        <div class="file-list">
+          <div *ngFor="let file of uploadedForms; let i = index" class="file-item">
+            <div class="file-info">
+              <span class="file-name" [title]="file.name">{{ file.name.length > 30 ? (file.name | slice:0:30) + '...' : file.name }}</span>
+              <span class="upload-date">{{ file.uploadDate | date:'short' }}</span>
+              <span class="file-status" *ngIf="file.isExisting">✓ Uploaded</span>
+            </div>
+            <div class="file-actions">
+              <button 
+                class="btn btn-primary btn-sm" 
+                *ngIf="file.file_path"
+                (click)="downloadConsentForm(file.file_path, file.name)">
+                Download
+              </button>
+              <button 
+                class="btn btn-danger btn-sm" 
+                *ngIf="!file.isExisting"
+                (click)="removeUploadedForm(i)">
+                Remove
+              </button>
+              <button 
+                class="btn btn-danger btn-sm" 
+                *ngIf="file.isExisting && !viewOnly"
+                (click)="deleteConsentForm(file.id)">
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
   </div>
 
   <!-- Download Mode -->

--- a/src/app/components/patients-section/treatment-plans/consent-form/consent-form.component.ts
+++ b/src/app/components/patients-section/treatment-plans/consent-form/consent-form.component.ts
@@ -65,6 +65,10 @@ export class ConsentFormComponent implements OnInit {
 
   @Output() closeDialog = new EventEmitter<void>();
 
+  onDialogClosed() {
+    this.uploadedForms = [];
+  }
+
   consentForm!: FormGroup;
   selectedMode: string | null = null;
   uploadedForms: any[] = [];

--- a/src/app/components/patients-section/treatment-plans/treatment-plans.component.html
+++ b/src/app/components/patients-section/treatment-plans/treatment-plans.component.html
@@ -170,7 +170,8 @@
     [modal]="true"
     [closable]="true"
     [style]="{ width: '50vw' }"
+    (onHide)="onConsentFormDialogClosed()"
   >
-    <app-consent-form [treatment]="selectedConsentTreatment"></app-consent-form>
+    <app-consent-form [treatment]="selectedConsentTreatment" #consentForm></app-consent-form>
   </p-dialog>
 </div>

--- a/src/app/components/patients-section/treatment-plans/treatment-plans.component.ts
+++ b/src/app/components/patients-section/treatment-plans/treatment-plans.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AbstractControl, FormArray, FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Procedure, TreatmentForm } from './treatment.interface';
@@ -57,9 +57,15 @@ export class TreatmentPlansComponent implements OnInit {
   savedPractice: any;
   consentFormVisible: boolean = false;
   selectedConsentTreatment: any;
+  @ViewChild('consentForm') consentForm!: ConsentFormComponent;
 
+  onConsentFormDialogClosed() {
+    if (this.consentForm) {
+      this.consentForm.onDialogClosed();
+    }
+  }
 
-consentform(plan: any): void {
+  consentform(plan: any): void {
   console.log('Consent form plan data:', plan);
   console.log('Treatment unique ID:', plan?.treatment_unique_id);
   console.log('Patient details:', plan?.patient_details_treat);


### PR DESCRIPTION
If an uploaded form is not submitted, and the dialog is closed, the form appears in other treatment plans buckets also. To fix this, upon dialog close, cleared the uploaded forms array.

Submitted forms are not affected.